### PR TITLE
Changed author search instruction to the correct menthod name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 Run an author search:
 
 ```ruby
-results = Google::Scholar::Base.author_search("author name")
+results = Google::Scholar::Base.search_author("author name")
 ```
 
 Get authors (as an enumerator):


### PR DESCRIPTION
Found a small error in the documentation that instructed users to search for author by using the method "author_search".  The actual method name is "author_search"
